### PR TITLE
Issue #95: prevent empty referenced course id coding error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -427,8 +427,12 @@ function subcourse_update_grades($subcourse, $userid=0, $nullifnone=true) {
     require_once($CFG->dirroot . '/mod/subcourse/locallib.php');
     require_once($CFG->libdir.'/gradelib.php');
 
-    $refgrades = subcourse_fetch_refgrades($subcourse->id, $subcourse->refcourse, false, $userid, false);
-
+    if ($subcourse->refcourse) {
+        $refgrades = subcourse_fetch_refgrades($subcourse->id, $subcourse->refcourse, false, $userid, false);
+    } else {
+        // Prevent empty referenced course id coding error
+        return GRADE_UPDATE_FAILED;
+    }
     if ($refgrades && $refgrades->grades) {
         if (!empty($refgrades->localremotescale)) {
             // Unable to fetch remote grades - local scale is used in the remote course.

--- a/lib.php
+++ b/lib.php
@@ -430,9 +430,10 @@ function subcourse_update_grades($subcourse, $userid=0, $nullifnone=true) {
     if ($subcourse->refcourse) {
         $refgrades = subcourse_fetch_refgrades($subcourse->id, $subcourse->refcourse, false, $userid, false);
     } else {
-        // Prevent empty referenced course id coding error
+        // Prevent empty referenced course id coding error.
         return GRADE_UPDATE_FAILED;
     }
+    
     if ($refgrades && $refgrades->grades) {
         if (!empty($refgrades->localremotescale)) {
             // Unable to fetch remote grades - local scale is used in the remote course.


### PR DESCRIPTION
Patch: Referenced course is checked before trying to update module grades, as the subcourse setting "Fetch grades from" can be set to None.