### PR TITLE
Atypical completion behavior

### DIFF
--- a/classes/completion/custom_completion.php
+++ b/classes/completion/custom_completion.php
@@ -43,18 +43,18 @@ class custom_completion extends \core_completion\activity_custom_completion {
 
         if (empty($subcourse->completioncourse)) {
             // The rule not enabled, return early.
-            return $type;
+            return COMPLETION_INCOMPLETE;
         }
 
         if (empty($subcourse->refcourse)) {
             // Misconfigured subcourse instance, behave as if was not enabled.
-            return $type;
+            return COMPLETION_INCOMPLETE;
         }
 
         // Check if the referenced course is completed.
         $coursecompletion = new \completion_completion(['userid' => $this->userid, 'course' => $subcourse->refcourse]);
 
-        return $coursecompletion->is_complete();
+        return $coursecompletion->is_complete()? COMPLETION_COMPLETE : COMPLETION_INCOMPLETE;
     }
 
     /**
@@ -78,6 +78,11 @@ class custom_completion extends \core_completion\activity_custom_completion {
      * @return array
      */
     public function get_sort_order(): array {
-        return ['completioncourse'];
+        return [
+            'completionview',
+            'completionusegrade',
+            'completionpassgrade',
+            'completioncourse'
+        ];
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -364,7 +364,7 @@ function subcourse_get_coursemodule_info($coursemodule) {
     global $CFG, $DB;
 
     $subcourse = $DB->get_record('subcourse', ['id' => $coursemodule->instance],
-        'id, name, intro, introformat, instantredirect, blankwindow, coursepageprintgrade, coursepageprintprogress');
+        'id, name, intro, introformat, instantredirect, blankwindow, coursepageprintgrade, coursepageprintprogress, completioncourse');
 
     if (!$subcourse) {
         return null;
@@ -386,6 +386,12 @@ function subcourse_get_coursemodule_info($coursemodule) {
         // Set content from intro and introformat. Filters are disabled because we filter with format_text at display time.
         $info->content = format_module_intro('subcourse', $subcourse, $coursemodule->id, false);
     }
+
+    // Populate the custom completion rules as key => value pairs, but only if the completion mode is 'automatic'.
+    if ($coursemodule->completion == COMPLETION_TRACKING_AUTOMATIC) {
+        $info->customdata->customcompletionrules['completioncourse'] = $subcourse->completioncourse;
+    }
+
 
     return $info;
 }


### PR DESCRIPTION
Usually in Moodle activities get completed when all of the set conditions are met. 
In the subcourse module the default conditions and the custom condition seem to be working independently. 
If you set "Student must receive a grade..." and "Student must complete the referenced course..." the activity will be completed if _either_ of these conditions is met instead of only when _both_ are met.
The changes in this pull request will require the user to meet all conditions.
