### PR TITLE
Fix #104 - return correct values in get_state call when subcourse not configured with completion.

### DIFF
--- a/classes/completion/custom_completion.php
+++ b/classes/completion/custom_completion.php
@@ -43,12 +43,12 @@ class custom_completion extends \core_completion\activity_custom_completion {
 
         if (empty($subcourse->completioncourse)) {
             // The rule not enabled, return early.
-            return $type;
+            return COMPLETION_UNKNOWN;
         }
 
         if (empty($subcourse->refcourse)) {
             // Misconfigured subcourse instance, behave as if was not enabled.
-            return $type;
+            return COMPLETION_INCOMPLETE;
         }
 
         // Check if the referenced course is completed.


### PR DESCRIPTION
This one is for the MOODLE_401_STABLE branch.